### PR TITLE
webpack - install nodejs core compatible module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4272,6 +4272,11 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5145,6 +5150,22 @@
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
       "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA==",
       "dev": true
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
     },
     "urlgrey": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "jquery-validation": "^1.19.3",
     "jsonschema": "^1.4.0",
     "lodash": "^4.17.21",
-    "sprintf-js": "^1.1.2"
+    "sprintf-js": "^1.1.2",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -72,11 +72,6 @@ const prepare = (mode, imageDir, outputPath) => {
         },
       ],
     },
-    resolve: {
-      fallback: {
-        'url': false,
-      },
-    },
   };
 };
 


### PR DESCRIPTION
|module|necessary for|
|---|---|
|`url`|`jsonschema`|

### Document

[resolve.fallback](https://webpack.js.org/configuration/resolve/#resolvefallback)

> Webpack 5 no longer polyfills Node.js core modules automatically which means if you use them in your code running in browsers or alike, you will have to install compatible modules from npm and include them yourself. Here is a list of polyfills webpack has used before webpack 5:

```js
module.exports = {
  //...
  resolve: {
    fallback: {
      assert: require.resolve('assert'),
      buffer: require.resolve('buffer'),
      console: require.resolve('console-browserify'),
      constants: require.resolve('constants-browserify'),
      crypto: require.resolve('crypto-browserify'),
      domain: require.resolve('domain-browser'),
      events: require.resolve('events'),
      http: require.resolve('stream-http'),
      https: require.resolve('https-browserify'),
      os: require.resolve('os-browserify/browser'),
      path: require.resolve('path-browserify'),
      punycode: require.resolve('punycode'),
      process: require.resolve('process/browser'),
      querystring: require.resolve('querystring-es3'),
      stream: require.resolve('stream-browserify'),
      string_decoder: require.resolve('string_decoder'),
      sys: require.resolve('util'),
      timers: require.resolve('timers-browserify'),
      tty: require.resolve('tty-browserify'),
      url: require.resolve('url'),
      util: require.resolve('util'),
      vm: require.resolve('vm-browserify'),
      zlib: require.resolve('browserify-zlib'),
    },
  },
};
```