### PR TITLE
Bootstrap 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1956,9 +1956,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
+      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og=="
     },
     "bootstrap-colorpicker": {
       "version": "3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3686,6 +3686,12 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "klona": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
+      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -4767,6 +4773,25 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sass": {
+      "version": "1.43.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.4.tgz",
+      "integrity": "sha512-/ptG7KE9lxpGSYiXn7Ar+lKOv37xfWsZRtFYal2QHNigyVQDx685VFT/h7ejVr+R8w7H4tmUgtulsKl5YpveOg==",
+      "dev": true,
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0"
+      }
+    },
+    "sass-loader": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.3.0.tgz",
+      "integrity": "sha512-6l9qwhdOb7qSrtOu96QQ81LVl8v6Dp9j1w3akOm0aWHyrTYtagDt5+kS32N4yq4hHk3M+rdqoRMH+lIdqvW6HA==",
+      "dev": true,
+      "requires": {
+        "klona": "^2.0.4",
+        "neo-async": "^2.6.2"
+      }
     },
     "saxes": {
       "version": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1956,16 +1956,18 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
+      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
     },
     "bootstrap-colorpicker": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/bootstrap-colorpicker/-/bootstrap-colorpicker-2.5.3.tgz",
-      "integrity": "sha512-xdllX8LSMvKULs3b8JrgRXTvyvjkSMHHHVuHjjN5FNMqr6kRe5NPiMHFmeAFjlgDF73MspikudLuEwR28LbzLw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-colorpicker/-/bootstrap-colorpicker-3.4.0.tgz",
+      "integrity": "sha512-7vA0hvLrat3ptobEKlT9+6amzBUJcDAoh6hJRQY/AD+5dVZYXXf1ivRfrTwmuwiVLJo9rZwM8YB4lYzp6agzqg==",
       "requires": {
-        "jquery": ">=1.10"
+        "bootstrap": ">=4.0",
+        "jquery": ">=2.2",
+        "popper.js": ">=1.10"
       }
     },
     "brace-expansion": {
@@ -4429,6 +4431,11 @@
           "dev": true
         }
       }
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "postcss": {
       "version": "8.3.11",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jquery": "^3.6.0",
     "jsonschema": "^1.4.0",
     "lodash": "^4.17.21",
+    "popper.js": "^1.16.1",
     "sprintf-js": "^1.1.2",
     "url": "^0.11.0"
   },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "mocha": "^9.1.3",
     "mocha-testdata": "^1.2.0",
     "mock-local-storage": "^1.1.17",
+    "sass": "^1.43.4",
+    "sass-loader": "^12.3.0",
     "sinon-chrome": "^3.0.1",
     "style-loader": "^3.3.1",
     "text-encoder": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "coverage:report": "istanbul cover _mocha -- test/* --require mock-local-storage && codecov"
   },
   "dependencies": {
-    "bootstrap": "^3.4.1",
-    "bootstrap-colorpicker": "^2.5.3",
+    "bootstrap": "^4.6.0",
+    "bootstrap-colorpicker": "^3.4.0",
     "clipboard": "^2.0.8",
     "deepmerge": "^4.2.2",
     "joi": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "coverage:report": "istanbul cover _mocha -- test/* --require mock-local-storage && codecov"
   },
   "dependencies": {
-    "bootstrap": "^4.6.0",
+    "bootstrap": "^4.6.1",
     "bootstrap-colorpicker": "^3.4.0",
     "clipboard": "^2.0.8",
     "deepmerge": "^4.2.2",

--- a/src/css/bootstrap-custom.css
+++ b/src/css/bootstrap-custom.css
@@ -22,10 +22,6 @@ body {
     font-size: 10px;
 }
 
-#js_pattern_list_badge {
-    margin-left: 10px;
-}
-
 .table .action .btn {
     margin-right: 10px;
 }

--- a/src/css/bootstrap-custom.css
+++ b/src/css/bootstrap-custom.css
@@ -28,10 +28,6 @@ body {
     border-radius: 3px;
 }
 
-.list-action-delete-confirm {
-    display: none;
-}
-
 .modal-dialog {
     margin-top: 80px;
 }

--- a/src/css/bootstrap-custom.css
+++ b/src/css/bootstrap-custom.css
@@ -7,7 +7,6 @@ body {
 #js_export_display {
     overflow-y: scroll;
     height: 200px;
-    font-size: 10px;
 }
 
 /**
@@ -15,7 +14,6 @@ body {
  */
 #js_form_import_json {
     font-family: SFMono-Regular, Menlo, Monaco,Consolas, "Liberation Mono", "Courier New", monospace;
-    font-size: 10px;
 }
 
 .modal-dialog {

--- a/src/css/bootstrap-custom.css
+++ b/src/css/bootstrap-custom.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 
 body {
-    padding-top: 70px;
+    padding-top: 80px;
 }
 
 #js_export_display {

--- a/src/css/bootstrap-custom.css
+++ b/src/css/bootstrap-custom.css
@@ -18,12 +18,6 @@ body {
     font-size: 10px;
 }
 
-.list-message {
-    text-align: center;
-    padding: 5px 10px;
-    border-radius: 3px;
-}
-
 .modal-dialog {
     margin-top: 80px;
 }

--- a/src/css/bootstrap-custom.css
+++ b/src/css/bootstrap-custom.css
@@ -18,10 +18,6 @@ body {
     font-size: 10px;
 }
 
-.table .action .btn {
-    margin-right: 10px;
-}
-
 .list-message {
     text-align: center;
     padding: 5px 10px;

--- a/src/css/bootstrap-custom.css
+++ b/src/css/bootstrap-custom.css
@@ -4,10 +4,6 @@ body {
     padding-top: 70px;
 }
 
-#js_version {
-    margin-left: 10px;
-}
-
 #js_export_display {
     overflow-y: scroll;
     height: 200px;

--- a/src/css/bootstrap-custom.css
+++ b/src/css/bootstrap-custom.css
@@ -11,10 +11,10 @@ body {
 }
 
 /**
- * font-family is same with the value for pre in bootstrap code.less
+ * font-family is same with the value for pre in bootstrap
  */
 #js_form_import_json {
-    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+    font-family: SFMono-Regular, Menlo, Monaco,Consolas, "Liberation Mono", "Courier New", monospace;
     font-size: 10px;
 }
 

--- a/src/css/options.scss
+++ b/src/css/options.scss
@@ -1,0 +1,3 @@
+$font-size-base: 0.9rem;
+
+@import "../../node_modules/bootstrap";

--- a/src/css/options.scss
+++ b/src/css/options.scss
@@ -1,3 +1,14 @@
+// Variables override
+
+// Color system
+
+$blue: #337ab7;
+$red: #d9534f;
+$yellow: #f0ad4e;
+$green: #5cb85c;
+
+// Typography
+
 $font-size-base: 0.9rem;
 
 @import "../../node_modules/bootstrap";

--- a/src/css/options.scss
+++ b/src/css/options.scss
@@ -7,6 +7,8 @@ $red: #d9534f;
 $yellow: #f0ad4e;
 $green: #5cb85c;
 
+$dark: #212529; // (= $gray-900)
+
 // Typography
 
 $font-size-base: 0.9rem;

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -35,7 +35,7 @@
 
 <script type="text/template" id="js_modal_pattern_html">
 <div id="js_modal_pattern" class="modal">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <form id="js_form_pattern" action="#">
                 <div class="modal-body">
@@ -111,7 +111,7 @@
 
 <script type="text/template" id="js_modal_delete_html">
 <div id="js_modal_delete" class="modal">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <form id="js_form_delete" action="#">
                 <div class="modal-body">
@@ -138,7 +138,7 @@
 
 <script type="text/template" id="js_modal_export_html">
 <div id="js_modal_export" class="modal">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-body">
                 <pre id="js_export_display" class="border p-2"></pre>
@@ -156,7 +156,7 @@
 
 <script type="text/template" id="js_modal_import_html">
 <div id="js_modal_import" class="modal">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <form id="js_form_import" action="#">
                 <div class="modal-body">

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -41,7 +41,7 @@
                 <div class="modal-body">
                     <div class="form-group">
                         <div for="js_input_url" data-i18n="label_url_pattern"></div>
-                        <p class="small text-info" data-i18n="text_url_pattern"></p>
+                        <p class="small text-dark" data-i18n="text_url_pattern"></p>
                         <input type="text" name="url" value="" id="js_input_url" class="form-control" data-i18n-ph="ph_url_pattern" placeholder="" />
                         <div id="js_input_url-error" class="js_input_error_message text-danger"></div>
                     </div>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -21,7 +21,8 @@
         </div>
     </nav>
 
-    <h2><span data-i18n="label_pattern_list"></span><span id="js_pattern_list_badge" class="badge badge-pill badge-secondary"><!-- 0 --></span></h2>
+    <h2><span class="align-middle" data-i18n="label_pattern_list"></span><span id="js_pattern_list_badge" class="align-middle badge badge-pill badge-secondary"></span></h2>
+
     <table id="js_list_pattern" class="table">
         <thead></thead>
         <tbody></tbody>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -46,7 +46,7 @@
                         <div id="js_input_url-error" class="js_input_error_message text-danger"></div>
                     </div>
                     <div class="form-group">
-                        <label for="js_input_msg" data-i18n="label_message"></label>
+                        <div for="js_input_msg" data-i18n="label_message"></div>
                         <input type="text" name="message" value="" id="js_input_msg" class="form-control" data-i18n-ph="ph_message" placeholder="" />
                         <div id="js_input_msg-error" class="js_input_error_message text-danger"></div>
                     </div>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -80,9 +80,9 @@
                 </div>
                 <div class="modal-footer">
                     <span id="js_pattern_message" class="text-danger"></span>
-                    <input id="js_form_pattern_submit" type="submit" class="btn btn-success" data-i18n-val="label_save" value="" />
+                    <input id="js_form_pattern_submit" type="submit" class="btn btn-primary" data-i18n-val="label_save" value="" />
                     <input id="js_form_pattern_clear" type="button" class="btn btn-warning" data-i18n-val="label_clear" value="" />
-                    <input id="js_form_pattern_cancel" type="button" class="btn btn-default" data-i18n-val="label_cancel" value="" data-dismiss="modal" />
+                    <input id="js_form_pattern_cancel" type="button" class="btn btn-secondary" data-i18n-val="label_cancel" value="" data-dismiss="modal" />
                 </div>
             </form>
         </div>
@@ -109,7 +109,7 @@
                 </div>
                 <div class="modal-footer">
                     <input id="js_form_delete_submit" type="submit" class="btn btn-danger" data-i18n-val="label_delete" value="" />
-                    <input id="js_form_delete_cancel" type="button" class="btn btn-default" data-i18n-val="label_cancel" value="" data-dismiss="modal" />
+                    <input id="js_form_delete_cancel" type="button" class="btn btn-secondary" data-i18n-val="label_cancel" value="" data-dismiss="modal" />
                 </div>
             </form>
         </div>
@@ -128,7 +128,7 @@
             </div>
             <div class="modal-footer">
                 <span id="js_export_message" class="text-success"></span>
-                <button id="js_export_copy" class="btn btn-default" data-clipboard-target="#js_export_display" data-i18n="label_copy"></button>
+                <button id="js_export_copy" class="btn btn-primary" data-clipboard-target="#js_export_display" data-i18n="label_copy"></button>
             </div>
         </div>
     </div>
@@ -150,8 +150,8 @@
                 </div>
                 <div class="modal-footer">
                     <span id="js_import_message" class="text-danger"></span>
-                    <input id="js_form_import_submit" type="submit" class="btn btn-success" data-i18n-val="label_import" value="" />
-                    <input id="js_form_import_cancel" type="button" class="btn btn-default" data-i18n-val="label_cancel" value="" data-dismiss="modal" />
+                    <input id="js_form_import_submit" type="submit" class="btn btn-primary" data-i18n-val="label_import" value="" />
+                    <input id="js_form_import_cancel" type="button" class="btn btn-secondary" data-i18n-val="label_cancel" value="" data-dismiss="modal" />
                 </div>
             </form>
         </div>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -8,16 +8,14 @@
 
 <div class="container">
 
-    <nav class="navbar navbar-inverse navbar-fixed-top">
+    <nav class="navbar navbar-expand fixed-top navbar-dark bg-dark">
         <div class="container">
-            <div class="navbar-header">
-                <span class="navbar-brand">Chrome URL Notification<span id="js_version"></span></span>
-            </div>
-            <div class="navbar-collapse collapse">
-                <ul class="nav navbar-nav">
-                    <li><a href="#" id="js_button_add_pattern" data-i18n="label_pattern_add"></a></li>
-                    <li><a href="#" id="js_button_export" data-i18n="label_export"></a></li>
-                    <li><a href="#" id="js_button_import" data-i18n="label_import"></a></li>
+            <span class="navbar-brand">Chrome URL Notification<span id="js_version"></span></span>
+            <div class="collapse navbar-collapse">
+                <ul class="navbar-nav mr-auto">
+                    <li class="nav-item"><a class="nav-link" href="#" id="js_button_add_pattern" data-i18n="label_pattern_add"></a></li>
+                    <li class="nav-item"><a class="nav-link" href="#" id="js_button_export" data-i18n="label_export"></a></li>
+                    <li class="nav-item"><a class="nav-link" href="#" id="js_button_import" data-i18n="label_import"></a></li>
                 </ul>
             </div>
         </div>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -59,15 +59,30 @@
                         <div id="js_input_background_color-error" class="js_input_error_message text-danger"></div>
                     </div>
                     <div class="form-group">
-                        <label data-i18n="label_display_position"></label>
-                        <div id="js_input_display_position" class="input-group">
-                            <label class="radio-inline"><input type="radio" value="top" name="display_position"><span data-i18n="label_top"></span></label>
-                            <label class="radio-inline"><input type="radio" value="bottom" name="display_position"><span data-i18n="label_bottom"></span></label>
-
-                            <label class="radio-inline"><input type="radio" value="top_left" name="display_position"><span data-i18n="label_top_left"></span></label>
-                            <label class="radio-inline"><input type="radio" value="top_right" name="display_position"><span data-i18n="label_top_right"></span></label>
-                            <label class="radio-inline"><input type="radio" value="bottom_left" name="display_position"><span data-i18n="label_bottom_left"></span></label>
-                            <label class="radio-inline"><input type="radio" value="bottom_right" name="display_position"><span data-i18n="label_bottom_right"></span></label>
+                        <div data-i18n="label_display_position"></div>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input" id="js_input_display_position_top" type="radio" name="display_position" value="top">
+                            <label class="form-check-label" for="js_input_display_position_top" data-i18n="label_top"></label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input" id="js_input_display_position_bottom" type="radio" name="display_position" value="bottom">
+                            <label class="form-check-label" for="js_input_display_position_bottom" data-i18n="label_bottom"></label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input" id="js_input_display_position_top_left" type="radio" name="display_position" value="top_left">
+                            <label class="form-check-label" for="js_input_display_position_top_left" data-i18n="label_top_left"></label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input" id="js_input_display_position_top_right" type="radio" name="display_position" value="top_right">
+                            <label class="form-check-label" for="js_input_display_position_top_right" data-i18n="label_top_right"></label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input" id="js_input_display_position_bottom_left" type="radio" name="display_position" value="bottom_left">
+                            <label class="form-check-label" for="js_input_display_position_bottom_left" data-i18n="label_bottom_left"></label>
+                        </div>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input" id="js_input_display_position_bottom_right" type="radio" name="display_position" value="bottom_right">
+                            <label class="form-check-label" for="js_input_display_position_bottom_right" data-i18n="label_bottom_right"></label>
                         </div>
                         <div id="js_input_display_position-error" class="js_input_error_message text-danger"></div>
                     </div>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -144,8 +144,8 @@
                 <pre id="js_export_display" class="border p-2"></pre>
             </div>
             <div class="modal-footer">
-                <span id="js_export_message" class="text-primary"></span>
-                <button id="js_export_copy" class="btn btn-primary" data-clipboard-target="#js_export_display" data-i18n="label_copy"></button>
+                <span id="js_export_message" class="text-success"></span>
+                <button id="js_export_copy" class="btn btn-success" data-clipboard-target="#js_export_display" data-i18n="label_copy"></button>
             </div>
         </div>
     </div>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -52,8 +52,8 @@
                     </div>
                     <div class="form-group">
                         <label for="js_input_background_color" data-i18n="label_background_color"></label>
-                        <div id="js_colorpicker" class="input-group colorpicker-component">
-                            <span class="input-group-addon"><i><!-- // --></i></span>
+                        <div id="js_colorpicker" class="input-group">
+                            <span class="input-group-prepend"><span class="input-group-text colorpicker-input-addon"><i></i></span></span>
                             <input type="text" name="background_color" value="" id="js_input_background_color" class="form-control" />
                         </div>
                         <div id="js_input_background_color-error" class="js_input_error_message text-danger"></div>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -21,7 +21,7 @@
         </div>
     </nav>
 
-    <h2><span data-i18n="label_pattern_list"></span><span id="js_pattern_list_badge" class="badge"><!-- 0 --></span></h2>
+    <h2><span data-i18n="label_pattern_list"></span><span id="js_pattern_list_badge" class="badge badge-pill badge-secondary"><!-- 0 --></span></h2>
     <table id="js_list_pattern" class="table">
         <thead></thead>
         <tbody></tbody>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -51,7 +51,7 @@
                         <div id="js_input_msg-error" class="js_input_error_message text-danger"></div>
                     </div>
                     <div class="form-group">
-                        <label for="js_input_background_color" data-i18n="label_background_color"></label>
+                        <div for="js_input_background_color" data-i18n="label_background_color"></div>
                         <div id="js_colorpicker" class="input-group">
                             <span class="input-group-prepend"><span class="input-group-text colorpicker-input-addon"><i></i></span></span>
                             <input type="text" name="background_color" value="" id="js_input_background_color" class="form-control" />

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -72,9 +72,10 @@
                         <div id="js_input_display_position-error" class="js_input_error_message text-danger"></div>
                     </div>
                     <div class="form-group">
-                        <label data-i18n="label_status"></label>
-                        <div class="input-group">
-                            <label class="checkbox-inline"><input id="js_input_status" type="checkbox" value="1" name="status"><span data-i18n="label_enabled"></span></label>
+                        <div data-i18n="label_status"></div>
+                        <div class="form-check">
+                            <input class="form-check-input" id="js_input_status" type="checkbox" value="1" name="status">
+                            <label class="form-check-label" for="js_input_status" data-i18n="label_enabled"></label>
                         </div>
                         <div id="js_input_status-error" class="js_input_error_message text-danger"></div>
                     </div>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -40,7 +40,7 @@
             <form id="js_form_pattern" action="#">
                 <div class="modal-body">
                     <div class="form-group">
-                        <label for="js_input_url" data-i18n="label_url_pattern"></label>
+                        <div for="js_input_url" data-i18n="label_url_pattern"></div>
                         <p class="small text-info" data-i18n="text_url_pattern"></p>
                         <input type="text" name="url" value="" id="js_input_url" class="form-control" data-i18n-ph="ph_url_pattern" placeholder="" />
                         <div id="js_input_url-error" class="js_input_error_message text-danger"></div>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -125,7 +125,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-body">
-                <pre id="js_export_display"></pre>
+                <pre id="js_export_display" class="border p-2"></pre>
             </div>
             <div class="modal-footer">
                 <span id="js_export_message" class="text-success"></span>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -21,7 +21,7 @@
         </div>
     </nav>
 
-    <h2><span class="align-middle" data-i18n="label_pattern_list"></span><span id="js_pattern_list_badge" class="align-middle badge badge-pill badge-secondary"></span></h2>
+    <h2><span class="align-middle" data-i18n="label_pattern_list"></span><span id="js_pattern_list_badge" class="ml-3 align-middle badge badge-pill badge-secondary"></span></h2>
 
     <table id="js_list_pattern" class="table">
         <thead></thead>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -10,7 +10,7 @@
 
     <nav class="navbar navbar-expand fixed-top navbar-dark bg-dark">
         <div class="container">
-            <span class="navbar-brand">Chrome URL Notification<span id="js_version"></span></span>
+            <span class="navbar-brand">Chrome URL Notification<span id="js_version" class="ml-3"></span></span>
             <div class="collapse navbar-collapse">
                 <ul class="navbar-nav mr-auto">
                     <li class="nav-item"><a class="nav-link" href="#" id="js_button_add_pattern" data-i18n="label_pattern_add"></a></li>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -128,7 +128,7 @@
                 <pre id="js_export_display" class="border p-2"></pre>
             </div>
             <div class="modal-footer">
-                <span id="js_export_message" class="text-success"></span>
+                <span id="js_export_message" class="text-primary"></span>
                 <button id="js_export_copy" class="btn btn-primary" data-clipboard-target="#js_export_display" data-i18n="label_copy"></button>
             </div>
         </div>

--- a/src/js/app/content.main.test.js
+++ b/src/js/app/content.main.test.js
@@ -1,7 +1,13 @@
 const chrome = require('sinon-chrome');
 
+//
+// Accessed from test code.
+//
 global.chrome = chrome;
 
+//
+// global.jQuery is accessed from test code.
+//
 const $ = global.jQuery = require('jquery');
 const pageInfoFactory = require('./content.pageInfo');
 const contentFind = require('./content.find');

--- a/src/js/app/options.list.js
+++ b/src/js/app/options.list.js
@@ -142,7 +142,8 @@ const makeRow = ($, item) => {
    * @returns {JQuery}
    */
   const container = (label, className) => {
-    return $('<div>')
+    return $('<span>')
+      .addClass('align-middle')
       .addClass(className)
       .text(label);
   };
@@ -171,7 +172,7 @@ const makeRow = ($, item) => {
      * @param {PatternItem} item
      */
     return (item) => {
-      return column().append(container(item.msg, 'list-message').css(css(item)));
+      return column().append(container(item.msg, 'list-message d-block').css(css(item)));
     };
   })();
 

--- a/src/js/app/options.list.js
+++ b/src/js/app/options.list.js
@@ -240,7 +240,7 @@ const makeRow = ($, item) => {
      * @param {PatternItem} item
      */
     const buttonCopy = (item) => {
-      return button(i18n.get('label_copy'), 'copy', item, 'btn-default');
+      return button(i18n.get('label_copy'), 'copy', item, 'btn-success');
     };
 
     /**

--- a/src/js/app/options.list.js
+++ b/src/js/app/options.list.js
@@ -230,7 +230,7 @@ const makeRow = ($, item) => {
      */
     const button = (label, action, item, className) => {
       return $('<button>')
-        .addClass(sprintf('btn btn-sm %s_button', action))
+        .addClass(sprintf('mr-1 btn btn-sm %s_button', action))
         .addClass(className)
         .attr('data-un-action', sprintf('pattern-item-%s', action))
         .attr('data-un-pattern-item', JSON.stringify(item))

--- a/src/js/app/options.list.js
+++ b/src/js/app/options.list.js
@@ -172,7 +172,7 @@ const makeRow = ($, item) => {
      * @param {PatternItem} item
      */
     return (item) => {
-      return column().append(container(item.msg, 'list-message d-block').css(css(item)));
+      return column().append(container(item.msg, 'list-message d-block p-1 rounded text-center').css(css(item)));
     };
   })();
 

--- a/src/js/app/options.main.js
+++ b/src/js/app/options.main.js
@@ -2,8 +2,7 @@ require('../../css/options.scss');
 require('bootstrap-colorpicker/dist/css/bootstrap-colorpicker.min.css');
 require('../../css/bootstrap-custom.css');
 
-// global.jQuery is necessary for bootstrap 3.
-const $ = global.jQuery = require('jquery');
+const $ = require('jquery');
 
 require('bootstrap');
 require('bootstrap-colorpicker');

--- a/src/js/app/options.main.js
+++ b/src/js/app/options.main.js
@@ -1,4 +1,4 @@
-require('bootstrap/dist/css/bootstrap.min.css');
+require('../../css/options.scss');
 require('bootstrap-colorpicker/dist/css/bootstrap-colorpicker.min.css');
 require('../../css/bootstrap-custom.css');
 

--- a/src/js/app/options.main.test.js
+++ b/src/js/app/options.main.test.js
@@ -1,7 +1,3 @@
-// require('bootstrap/dist/css/bootstrap.min.css');
-// require('bootstrap-colorpicker/dist/css/bootstrap-colorpicker.min.css');
-// require('../../css/bootstrap-custom.css');
-
 const chrome = require('sinon-chrome');
 
 chrome.runtime.getManifest
@@ -9,12 +5,19 @@ chrome.runtime.getManifest
     version: '1.2.3',
   });
 
+//
+// Accessed from test code.
+//
 global.chrome = chrome;
 
+//
 // Necessary for @sideway/address/lib/email.js, used by joi.
+//
 global.TextEncoder = require('text-encoder').TextEncoder;
 
-// global.jQuery is necessary for bootstrap 3.
+//
+// global.jQuery is accessed from test code.
+//
 const $ = global.jQuery = require('jquery');
 
 require('bootstrap');

--- a/src/js/app/options.patternForm.js
+++ b/src/js/app/options.patternForm.js
@@ -25,8 +25,13 @@ const defaultValues = () => {
 const bindValues = ($, item) => {
   $('#js_input_url').val(item.url);
   $('#js_input_msg').val(item.msg);
-  $('#js_input_background_color').val('#' + item.backgroundColor);
-  $('#js_colorpicker').colorpicker('setValue', '#' + item.backgroundColor);
+  $('#js_input_background_color').val('#' + item.backgroundColor.toUpperCase());
+  $('#js_colorpicker')
+    .colorpicker({
+      color: '#' + item.backgroundColor.toUpperCase(),
+      format: 'hex',
+    })
+    .colorpicker('setValue', '#' + item.backgroundColor.toUpperCase());
   $('input[name=display_position]').val([item.displayPosition]);
   $('#js_input_status').prop('checked', item.status === 1);
 };
@@ -82,11 +87,6 @@ const clear = ($) => {
  */
 const show = ($, mode, item, callback) => {
   formFactory.initForm($, '#js_modal_pattern_container', '#js_modal_pattern_html');
-
-  $('#js_colorpicker').colorpicker({
-    fallbackColor: '#000000',
-    format: 'hex',
-  });
 
   $('#js_form_pattern_clear').on('click', (e) => {
     e.preventDefault();

--- a/src/js/app/options.patternForm.js
+++ b/src/js/app/options.patternForm.js
@@ -81,9 +81,6 @@ const clear = ($) => {
  * @param {function} callback
  */
 const show = ($, mode, item, callback) => {
-  require('bootstrap');
-  require('bootstrap-colorpicker');
-
   formFactory.initForm($, '#js_modal_pattern_container', '#js_modal_pattern_html');
 
   $('#js_colorpicker').colorpicker({

--- a/src/js/app/options.patternForm.js
+++ b/src/js/app/options.patternForm.js
@@ -84,7 +84,6 @@ const show = ($, mode, item, callback) => {
   formFactory.initForm($, '#js_modal_pattern_container', '#js_modal_pattern_html');
 
   $('#js_colorpicker').colorpicker({
-    align: 'left',
     format: 'hex',
   });
 

--- a/src/js/app/options.patternForm.js
+++ b/src/js/app/options.patternForm.js
@@ -39,7 +39,7 @@ const getRawValues = ($) => {
   return {
     url: $('#js_input_url').val(),
     msg: $('#js_input_msg').val(),
-    background_color: $('#js_input_background_color').val().replace(/^#/, ''),
+    background_color: $('#js_input_background_color').val().replace(/^#/, '').toLowerCase(),
     display_position: $('input[name=display_position]:checked').val(),
     status: $('#js_input_status').val(),
   };
@@ -53,7 +53,7 @@ const getValues = ($) => {
   return {
     url: $('#js_input_url').val().trim(),
     msg: $('#js_input_msg').val().trim(),
-    backgroundColor: $('#js_input_background_color').val().trim().replace(/^#/, ''),
+    backgroundColor: $('#js_input_background_color').val().trim().replace(/^#/, '').toLowerCase(),
     displayPosition: $('input[name=display_position]:checked').val().trim(),
     status: $('#js_input_status').is(':checked') ? 1 : 0,
   };

--- a/src/js/app/options.patternForm.js
+++ b/src/js/app/options.patternForm.js
@@ -84,6 +84,7 @@ const show = ($, mode, item, callback) => {
   formFactory.initForm($, '#js_modal_pattern_container', '#js_modal_pattern_html');
 
   $('#js_colorpicker').colorpicker({
+    fallbackColor: '#000000',
     format: 'hex',
   });
 

--- a/src/js/app/options.patternForm.js
+++ b/src/js/app/options.patternForm.js
@@ -81,6 +81,9 @@ const clear = ($) => {
  * @param {function} callback
  */
 const show = ($, mode, item, callback) => {
+  require('bootstrap');
+  require('bootstrap-colorpicker');
+
   formFactory.initForm($, '#js_modal_pattern_container', '#js_modal_pattern_html');
 
   $('#js_colorpicker').colorpicker({

--- a/src/js/app/popup.main.test.js
+++ b/src/js/app/popup.main.test.js
@@ -1,9 +1,13 @@
-// require('../../css/popup.css');
-
 const chrome = require('sinon-chrome');
 
+//
+// Accessed from test code.
+//
 global.chrome = chrome;
 
+//
+// global.jQuery is accessed from test code.
+//
 const $ = global.jQuery = require('jquery');
 const ui = require('./popup.ui');
 

--- a/test/app/options.pattern.actions.js
+++ b/test/app/options.pattern.actions.js
@@ -157,7 +157,7 @@ describe('app.options.pattern.actions', () => {
 
       assert.strictEqual(form.pattern(), 'domain11.example.com');
       assert.strictEqual(form.message(), 'domain11');
-      assert.strictEqual(form.backgroundColor(), '#cccccc');
+      assert.strictEqual(form.backgroundColor(), '#CCCCCC');
       assert.strictEqual(form.displayPosition(), 'bottom');
       assert.strictEqual(form.status(), true);
     });

--- a/test/app/options.pattern.add.js
+++ b/test/app/options.pattern.add.js
@@ -94,5 +94,19 @@ describe('app.options.pattern.add', function () {
       assert.strictEqual(item.displayPosition(), 'Top');
       assert.strictEqual(item.status(), 'Y');
     });
+
+    it('colorpicker data on storage', () => {
+      const form = options.patternForm();
+
+      form.pattern('site2.example.com');
+      form.message('site2.example');
+      form.backgroundColor('#B45D5D');
+      form.submit();
+
+      assert.strictEqual(storage.getCount(), 1);
+
+      const item = storage.getAll()[0];
+      assert.strictEqual(item.backgroundColor, 'b45d5d');
+    });
   });
 });

--- a/test/app/options.pattern.add.js
+++ b/test/app/options.pattern.add.js
@@ -95,7 +95,7 @@ describe('app.options.pattern.add', function () {
       assert.strictEqual(item.status(), 'Y');
     });
 
-    it('colorpicker data on storage', () => {
+    it('colorpicker data in storage', () => {
       const form = options.patternForm();
 
       form.pattern('site2.example.com');

--- a/test/app/options.pattern.edit.js
+++ b/test/app/options.pattern.edit.js
@@ -78,7 +78,7 @@ describe('app.options.pattern.edit', function () {
         {
           url: 'domain9.example.com',
           msg: 'domain9',
-          backgroundColor: '111111',
+          backgroundColor: '0044cc',
           displayPosition: 'top',
           status: 0,
         },
@@ -93,9 +93,18 @@ describe('app.options.pattern.edit', function () {
 
       assert.strictEqual(form.pattern(), 'domain9.example.com');
       assert.strictEqual(form.message(), 'domain9');
-      assert.strictEqual(form.backgroundColor(), '#111111');
+      assert.strictEqual(form.backgroundColor(), '#0044CC');
       assert.strictEqual(form.displayPosition(), 'top');
       assert.strictEqual(form.status(), false);
+    });
+
+    it('colorpicker data on storage', () => {
+      const form = options.patternForm();
+
+      form.submit();
+
+      const item = storage.getAll()[0];
+      assert.strictEqual(item.backgroundColor, '0044cc');
     });
 
     it('keeping original pattern is not an error', () => {

--- a/test/app/options.pattern.edit.js
+++ b/test/app/options.pattern.edit.js
@@ -98,7 +98,7 @@ describe('app.options.pattern.edit', function () {
       assert.strictEqual(form.status(), false);
     });
 
-    it('colorpicker data on storage', () => {
+    it('colorpicker data in storage', () => {
       const form = options.patternForm();
 
       form.submit();

--- a/test_lib/options.js
+++ b/test_lib/options.js
@@ -73,14 +73,14 @@ class FormBase {
    * that element has following class attributes.
    *
    * - modal
-   * - in
+   * - show
    *
    * @param {JQuery} element
    * @returns {boolean}
    * @protected
    */
   _modalIsActivated(element) {
-    return element.hasClass('modal') && element.hasClass('in');
+    return element.hasClass('modal') && element.hasClass('show');
   }
 
   /**

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -66,6 +66,14 @@ const prepare = (mode, imageDir, outputPath) => {
           ],
         },
         {
+          test: /\.s[ac]ss$/i,
+          use: [
+            'style-loader',
+            'css-loader',
+            'sass-loader',
+          ],
+        },
+        {
           // More information here https://webpack.js.org/guides/asset-modules/
           test: /\.(svg|eot|ttf|woff|woff2)$/i,
           type: 'asset',


### PR DESCRIPTION
- `bootstrap` (`4.6.1`)
- `bootstrap-colorpicker` (`3.4.0`)

## Related topics

https://github.com/itsjavi/bootstrap-colorpicker/issues/333

It seems that spec has been changed to handle hex color as uppercase.

In existing releases, background color is managed as lowercase in local storage.

So change code to:

- Call `.toUpperCase()` against fetched data when initializing colorpicker.
- Call `.toLowerCase()` when saving data.